### PR TITLE
RPC_KEYBOARD

### DIFF
--- a/alloc/flip_social_alloc.c
+++ b/alloc/flip_social_alloc.c
@@ -176,11 +176,11 @@ FlipSocialApp *flip_social_app_alloc()
     }
 
     // Allocate Submenu(s)
-    if (!easy_flipper_set_submenu(&app->submenu_logged_out, FlipSocialViewLoggedOutSubmenu, "FlipSocial v0.7", flip_social_callback_exit_app, &app->view_dispatcher))
+    if (!easy_flipper_set_submenu(&app->submenu_logged_out, FlipSocialViewLoggedOutSubmenu, "FlipSocial v0.8", flip_social_callback_exit_app, &app->view_dispatcher))
     {
         return NULL;
     }
-    if (!easy_flipper_set_submenu(&app->submenu_logged_in, FlipSocialViewLoggedInSubmenu, "FlipSocial v0.7", flip_social_callback_exit_app, &app->view_dispatcher))
+    if (!easy_flipper_set_submenu(&app->submenu_logged_in, FlipSocialViewLoggedInSubmenu, "FlipSocial v0.8", flip_social_callback_exit_app, &app->view_dispatcher))
     {
         return NULL;
     }

--- a/application.fam
+++ b/application.fam
@@ -9,6 +9,6 @@ App(
     fap_icon_assets="assets",
     fap_author="jblanked",
     fap_weburl="https://github.com/jblanked/FlipSocial",
-    fap_version="0.7",
+    fap_version="0.8",
     fap_description="Social media platform for the Flipper Zero.",
 )

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.8
+- Add support for RPC_KEYBOARD
+
 ## 0.7
 - Improved memory allocation
 - Increased the max explore users from 50 to 100

--- a/text_input/rpc_keyboard.h
+++ b/text_input/rpc_keyboard.h
@@ -1,0 +1,162 @@
+#pragma once
+
+#include <core/common_defines.h>
+#include <core/mutex.h>
+#include <core/pubsub.h>
+
+#define RECORD_RPC_KEYBOARD "rpckeyboard"
+
+#define RPC_KEYBOARD_KEY_RIGHT '\x13'
+#define RPC_KEYBOARD_KEY_LEFT '\x14'
+#define RPC_KEYBOARD_KEY_ENTER '\x0D'
+#define RPC_KEYBOARD_KEY_BACKSPACE '\x08'
+
+typedef enum
+{
+    // Unknown error occurred
+    RpcKeyboardChatpadStatusError,
+    // The chatpad worker is stopped
+    RpcKeyboardChatpadStatusStopped,
+    // The chatpad worker is started, but not ready
+    RpcKeyboardChatpadStatusStarted,
+    // The chatpad worker is ready and got response from chatpad
+    RpcKeyboardChatpadStatusReady,
+} RpcKeyboardChatpadStatus;
+
+typedef struct RpcKeyboard RpcKeyboard;
+
+typedef enum
+{
+    // Replacement text was provided by the user
+    RpcKeyboardEventTypeTextEntered,
+    // A single character was provided by the user
+    RpcKeyboardEventTypeCharEntered,
+    // A macro was entered by the user
+    RpcKeyboardEventTypeMacroEntered,
+} RpcKeyboardEventType;
+
+typedef struct
+{
+    // The mutex to protect the data, call furi_mutex_acquire/furi_mutex_release.
+    FuriMutex *mutex;
+    // The text message, macro or character.
+    char message[256];
+    // The length of the message.
+    uint16_t length;
+    // The newline enabled flag, allow newline to submit text.
+    bool newline_enabled;
+} RpcKeyboardEventData;
+
+typedef struct
+{
+    RpcKeyboardEventType type;
+    RpcKeyboardEventData data;
+} RpcKeyboardEvent;
+
+typedef FuriPubSub *(*RpcKeyboardGetPubsub)(RpcKeyboard *rpc_keyboard);
+typedef void (*RpcKeyboardNewlineEnable)(RpcKeyboard *rpc_keyboard, bool enable);
+typedef void (*RpcKeyboardPublishCharFn)(RpcKeyboard *keyboard, char character);
+typedef void (*RpcKeyboardPublishMacroFn)(RpcKeyboard *rpc_keyboard, char macro);
+typedef char *(*RpcKeyboardGetMacroFn)(RpcKeyboard *rpc_keyboard, char macro);
+typedef void (*RpcKeyboardSetMacroFn)(RpcKeyboard *rpc_keyboard, char macro, char *value);
+typedef void (*RpcKeyboardChatpadStartFn)(RpcKeyboard *rpc_keyboard);
+typedef void (*RpcKeyboardChatpadStopFn)(RpcKeyboard *rpc_keyboard);
+typedef RpcKeyboardChatpadStatus (*RpcKeyboardChatpadStatusFn)(RpcKeyboard *rpc_keyboard);
+
+typedef struct RpcKeyboardFunctions RpcKeyboardFunctions;
+struct RpcKeyboardFunctions
+{
+    uint16_t major;
+    uint16_t minor;
+    RpcKeyboardGetPubsub fn_get_pubsub;
+    RpcKeyboardNewlineEnable fn_newline_enable;
+    RpcKeyboardPublishCharFn fn_publish_char;
+    RpcKeyboardPublishMacroFn fn_publish_macro;
+    RpcKeyboardGetMacroFn fn_get_macro;
+    RpcKeyboardSetMacroFn fn_set_macro;
+    RpcKeyboardChatpadStartFn fn_chatpad_start;
+    RpcKeyboardChatpadStopFn fn_chatpad_stop;
+    RpcKeyboardChatpadStatusFn fn_chatpad_status;
+};
+
+/**
+ * @brief STARTUP - Register the remote keyboard.
+ */
+void rpc_keyboard_register(void);
+
+/**
+ * @brief UNUSED - Unregister the remote keyboard.
+ */
+void rpc_keyboard_release(void);
+
+/**
+ * @brief Get the pubsub object for the remote keyboard.
+ * @details This function returns the pubsub object, use to subscribe to keyboard events.
+ * @param[in] rpc_keyboard pointer to the RECORD_RPC_KEYBOARD.
+ * @return FuriPubSub* pointer to the pubsub object.
+ */
+FuriPubSub *rpc_keyboard_get_pubsub(RpcKeyboard *rpc_keyboard);
+
+/**
+ * @brief Enable or disable newline character submitting the text.
+ * @param[in] rpc_keyboard pointer to the RECORD_RPC_KEYBOARD.
+ * @param[in] enable true to enable, false to disable.
+ */
+void rpc_keyboard_newline_enable(RpcKeyboard *rpc_keyboard, bool enable);
+
+/**
+ * @brief Publish the replacement text to the remote keyboard.
+ * @param[in] rpc_keyboard pointer to the RECORD_RPC_KEYBOARD.
+ * @param[in] bytes pointer to the text buffer.
+ * @param[in] buffer_size size of the text buffer.
+ */
+void rpc_keyboard_publish_text(RpcKeyboard *rpc_keyboard, uint8_t *bytes, uint32_t buffer_size);
+
+/**
+ * @brief Publish a single key pressed on the remote keyboard.
+ * @param[in] rpc_keyboard pointer to the RECORD_RPC_KEYBOARD.
+ * @param[in] character the character that was pressed.
+ */
+void rpc_keyboard_publish_char(RpcKeyboard *rpc_keyboard, char character);
+
+/**
+ * @brief Publish a macro key pressed on the remote keyboard.
+ * @param[in] rpc_keyboard pointer to the RECORD_RPC_KEYBOARD.
+ * @param[in] character the macro key that was pressed.
+ */
+void rpc_keyboard_publish_macro(RpcKeyboard *rpc_keyboard, char macro);
+
+/**
+ * @brief Get the macro text associated with a macro key.
+ * @param[in] rpc_keyboard pointer to the RECORD_RPC_KEYBOARD.
+ * @param[in] macro the macro key.
+ * @return char* pointer to the macro text. NULL if the macro key is not set. User must free the memory.
+ */
+char *rpc_keyboard_get_macro(RpcKeyboard *rpc_keyboard, char macro);
+
+/**
+ * @brief Set the macro text associated with a macro key.
+ * @param[in] rpc_keyboard pointer to the RECORD_RPC_KEYBOARD.
+ * @param[in] macro the macro key.
+ * @param[in] value the macro text.
+ */
+void rpc_keyboard_set_macro(RpcKeyboard *rpc_keyboard, char macro, char *value);
+
+/**
+ * @brief Initializes the chatpad and starts listening for keypresses.
+ * @param[in] rpc_keyboard pointer to the RECORD_RPC_KEYBOARD.
+ */
+void rpc_keyboard_chatpad_start(RpcKeyboard *rpc_keyboard);
+
+/**
+ * @brief Stops the chatpad & frees resources.
+ * @param[in] rpc_keyboard pointer to the RECORD_RPC_KEYBOARD.
+ */
+void rpc_keyboard_chatpad_stop(RpcKeyboard *rpc_keyboard);
+
+/**
+ * @brief Get the status of the chatpad.
+ * @param[in] rpc_keyboard pointer to the RECORD_RPC_KEYBOARD.
+ * @return RpcKeyboardChatpadStatus the status of the chatpad.
+ */
+RpcKeyboardChatpadStatus rpc_keyboard_chatpad_status(RpcKeyboard *rpc_keyboard);

--- a/text_input/rpc_keyboard_stub.c
+++ b/text_input/rpc_keyboard_stub.c
@@ -1,0 +1,150 @@
+#include "rpc_keyboard.h"
+
+#include <furi.h>
+
+static bool rpc_keyboard_functions_check_version(RpcKeyboardFunctions *stub)
+{
+    furi_check(stub);
+    if (stub->major == 1 && stub->minor > 2)
+    {
+        return true;
+    }
+    FURI_LOG_D("RpcKeyboard", "Unsupported version %d.%d", stub->major, stub->minor);
+    return false;
+}
+
+/**
+ * @brief Get the pubsub object for the remote keyboard.
+ * @details This function returns the pubsub object, use to subscribe to keyboard events.
+ * @param[in] rpc_keyboard pointer to the RECORD_RPC_KEYBOARD.
+ * @return FuriPubSub* pointer to the pubsub object.
+ */
+FuriPubSub *rpc_keyboard_get_pubsub(RpcKeyboard *rpc_keyboard)
+{
+    RpcKeyboardFunctions *stub = (RpcKeyboardFunctions *)rpc_keyboard;
+    if (!rpc_keyboard_functions_check_version(stub))
+    {
+        return NULL;
+    }
+    return stub->fn_get_pubsub((RpcKeyboard *)rpc_keyboard);
+}
+
+/**
+ * @brief Enable or disable newline character submitting the text.
+ * @param[in] rpc_keyboard pointer to the RECORD_RPC_KEYBOARD.
+ * @param[in] enable true to enable, false to disable.
+ */
+void rpc_keyboard_newline_enable(RpcKeyboard *rpc_keyboard, bool enable)
+{
+    RpcKeyboardFunctions *stub = (RpcKeyboardFunctions *)rpc_keyboard;
+    if (!rpc_keyboard_functions_check_version(stub))
+    {
+        return;
+    }
+    stub->fn_newline_enable((RpcKeyboard *)rpc_keyboard, enable);
+}
+
+/**
+ * @brief Publish a single key pressed on the remote keyboard.
+ * @param[in] rpc_keyboard pointer to the RECORD_RPC_KEYBOARD.
+ * @param[in] character the character that was pressed.
+ */
+void rpc_keyboard_publish_char(RpcKeyboard *rpc_keyboard, char character)
+{
+    RpcKeyboardFunctions *stub = (RpcKeyboardFunctions *)rpc_keyboard;
+    if (!rpc_keyboard_functions_check_version(stub))
+    {
+        return;
+    }
+    stub->fn_publish_char((RpcKeyboard *)rpc_keyboard, character);
+}
+
+/**
+ * @brief Publish a macro key pressed on the remote keyboard.
+ * @param[in] rpc_keyboard pointer to the RECORD_RPC_KEYBOARD.
+ * @param[in] character the macro key that was pressed.
+ */
+void rpc_keyboard_publish_macro(RpcKeyboard *rpc_keyboard, char macro)
+{
+    RpcKeyboardFunctions *stub = (RpcKeyboardFunctions *)rpc_keyboard;
+    if (!rpc_keyboard_functions_check_version(stub))
+    {
+        return;
+    }
+    stub->fn_publish_macro((RpcKeyboard *)rpc_keyboard, macro);
+}
+
+/**
+ * @brief Get the macro text associated with a macro key.
+ * @param[in] rpc_keyboard pointer to the RECORD_RPC_KEYBOARD.
+ * @param[in] macro the macro key.
+ * @return char* pointer to the macro text. NULL if the macro key is not set. User must free the memory.
+ */
+char *rpc_keyboard_get_macro(RpcKeyboard *rpc_keyboard, char macro)
+{
+    RpcKeyboardFunctions *stub = (RpcKeyboardFunctions *)rpc_keyboard;
+    if (!rpc_keyboard_functions_check_version(stub))
+    {
+        return NULL;
+    }
+    return stub->fn_get_macro((RpcKeyboard *)rpc_keyboard, macro);
+}
+
+/**
+ * @brief Set the macro text associated with a macro key.
+ * @param[in] rpc_keyboard pointer to the RECORD_RPC_KEYBOARD.
+ * @param[in] macro the macro key.
+ * @param[in] value the macro text.
+ */
+void rpc_keyboard_set_macro(RpcKeyboard *rpc_keyboard, char macro, char *value)
+{
+    RpcKeyboardFunctions *stub = (RpcKeyboardFunctions *)rpc_keyboard;
+    if (!rpc_keyboard_functions_check_version(stub))
+    {
+        return;
+    }
+    stub->fn_set_macro((RpcKeyboard *)rpc_keyboard, macro, value);
+}
+
+/**
+ * @brief Initializes the chatpad and starts listening for keypresses.
+ * @param[in] rpc_keyboard pointer to the RECORD_RPC_KEYBOARD.
+ */
+void rpc_keyboard_chatpad_start(RpcKeyboard *rpc_keyboard)
+{
+    RpcKeyboardFunctions *stub = (RpcKeyboardFunctions *)rpc_keyboard;
+    if (!rpc_keyboard_functions_check_version(stub))
+    {
+        return;
+    }
+    stub->fn_chatpad_start((RpcKeyboard *)rpc_keyboard);
+}
+
+/**
+ * @brief Stops the chatpad & frees resources.
+ * @param[in] rpc_keyboard pointer to the RECORD_RPC_KEYBOARD.
+ */
+void rpc_keyboard_chatpad_stop(RpcKeyboard *rpc_keyboard)
+{
+    RpcKeyboardFunctions *stub = (RpcKeyboardFunctions *)rpc_keyboard;
+    if (!rpc_keyboard_functions_check_version(stub))
+    {
+        return;
+    }
+    stub->fn_chatpad_stop((RpcKeyboard *)rpc_keyboard);
+}
+
+/**
+ * @brief Get the status of the chatpad.
+ * @param[in] rpc_keyboard pointer to the RECORD_RPC_KEYBOARD.
+ * @return RpcKeyboardChatpadStatus the status of the chatpad.
+ */
+RpcKeyboardChatpadStatus rpc_keyboard_chatpad_status(RpcKeyboard *rpc_keyboard)
+{
+    RpcKeyboardFunctions *stub = (RpcKeyboardFunctions *)rpc_keyboard;
+    if (!rpc_keyboard_functions_check_version(stub))
+    {
+        return RpcKeyboardChatpadStatusError;
+    }
+    return stub->fn_chatpad_status((RpcKeyboard *)rpc_keyboard);
+}

--- a/text_input/uart_text_input.c
+++ b/text_input/uart_text_input.c
@@ -348,17 +348,17 @@ static void uart_text_input_view_draw_callback(Canvas *canvas, void *_model)
                 if (model->selected_row == row && model->selected_column == column)
                 {
                     canvas_draw_icon(
-                        canvas, 
-                        keyboard_origin_x + keys[column].x, 
+                        canvas,
+                        keyboard_origin_x + keys[column].x,
                         keyboard_origin_y + keys[column].y,
                         &I_KeySaveSelected_24x11);
                 }
                 else
                 {
                     canvas_draw_icon(
-                        canvas, 
-                        keyboard_origin_x + keys[column].x, 
-                        keyboard_origin_y + keys[column].y, 
+                        canvas,
+                        keyboard_origin_x + keys[column].x,
+                        keyboard_origin_y + keys[column].y,
                         &I_KeySave_24x11);
                 }
             }
@@ -368,17 +368,17 @@ static void uart_text_input_view_draw_callback(Canvas *canvas, void *_model)
                 if (model->selected_row == row && model->selected_column == column)
                 {
                     canvas_draw_icon(
-                        canvas, 
-                        keyboard_origin_x + keys[column].x, 
-                        keyboard_origin_y + keys[column].y, 
+                        canvas,
+                        keyboard_origin_x + keys[column].x,
+                        keyboard_origin_y + keys[column].y,
                         &I_KeyBackspaceSelected_16x9);
                 }
                 else
                 {
                     canvas_draw_icon(
-                        canvas, 
-                        keyboard_origin_x + keys[column].x, 
-                        keyboard_origin_y + keys[column].y, 
+                        canvas,
+                        keyboard_origin_x + keys[column].x,
+                        keyboard_origin_y + keys[column].y,
                         &I_KeyBackspace_16x9);
                 }
             }
@@ -388,10 +388,10 @@ static void uart_text_input_view_draw_callback(Canvas *canvas, void *_model)
                 {
                     canvas_set_color(canvas, ColorBlack);
                     canvas_draw_box(
-                        canvas, 
-                        keyboard_origin_x + keys[column].x - 1, 
-                        keyboard_origin_y + keys[column].y - 8, 
-                        7, 
+                        canvas,
+                        keyboard_origin_x + keys[column].x - 1,
+                        keyboard_origin_y + keys[column].y - 8,
+                        7,
                         10);
                     canvas_set_color(canvas, ColorWhite);
                 }
@@ -402,17 +402,17 @@ static void uart_text_input_view_draw_callback(Canvas *canvas, void *_model)
                 if (0 == strcmp(model->header, mode_AT))
                 {
                     canvas_draw_glyph(
-                        canvas, 
-                        keyboard_origin_x + keys[column].x, 
-                        keyboard_origin_y + keys[column].y, 
+                        canvas,
+                        keyboard_origin_x + keys[column].x,
+                        keyboard_origin_y + keys[column].y,
                         char_to_uppercase(keys[column].text));
                 }
                 else
                 {
                     canvas_draw_glyph(
-                        canvas, 
-                        keyboard_origin_x + keys[column].x, 
-                        keyboard_origin_y + keys[column].y, 
+                        canvas,
+                        keyboard_origin_x + keys[column].x,
+                        keyboard_origin_y + keys[column].y,
                         keys[column].text);
                 }
             }
@@ -432,7 +432,7 @@ static void uart_text_input_view_draw_callback(Canvas *canvas, void *_model)
     }
 }
 
-static void 
+static void
 uart_text_input_handle_up(UART_TextInput *uart_text_input, UART_TextInputModel *model)
 {
     UNUSED(uart_text_input);
@@ -446,7 +446,7 @@ uart_text_input_handle_up(UART_TextInput *uart_text_input, UART_TextInputModel *
     }
 }
 
-static void 
+static void
 uart_text_input_handle_down(UART_TextInput *uart_text_input, UART_TextInputModel *model)
 {
     UNUSED(uart_text_input);
@@ -460,7 +460,7 @@ uart_text_input_handle_down(UART_TextInput *uart_text_input, UART_TextInputModel
     }
 }
 
-static void 
+static void
 uart_text_input_handle_left(UART_TextInput *uart_text_input, UART_TextInputModel *model)
 {
     UNUSED(uart_text_input);
@@ -474,7 +474,7 @@ uart_text_input_handle_left(UART_TextInput *uart_text_input, UART_TextInputModel
     }
 }
 
-static void 
+static void
 uart_text_input_handle_right(UART_TextInput *uart_text_input, UART_TextInputModel *model)
 {
     UNUSED(uart_text_input);
@@ -489,8 +489,8 @@ uart_text_input_handle_right(UART_TextInput *uart_text_input, UART_TextInputMode
 }
 
 static void uart_text_input_handle_ok(
-    UART_TextInput *uart_text_input, 
-    UART_TextInputModel *model, 
+    UART_TextInput *uart_text_input,
+    UART_TextInputModel *model,
     bool shift)
 {
     char selected = get_selected_char(model);
@@ -556,7 +556,7 @@ static bool uart_text_input_view_input_callback(InputEvent *event, void *context
     // Acquire model
     UART_TextInputModel *model = view_get_model(uart_text_input->view);
 
-    if ((!(event->type == InputTypePress) && !(event->type == InputTypeRelease)) && 
+    if ((!(event->type == InputTypePress) && !(event->type == InputTypeRelease)) &&
         model->valadator_message_visible)
     {
         model->valadator_message_visible = false;
@@ -857,13 +857,13 @@ UART_TextInput *uart_text_input_alloc()
     view_set_enter_callback(uart_text_input->view, text_input_view_enter_callback);
     view_set_exit_callback(uart_text_input->view, text_input_view_exit_callback);
 
-    uart_text_input->timer = 
+    uart_text_input->timer =
         furi_timer_alloc(uart_text_input_timer_callback, FuriTimerTypeOnce, uart_text_input);
 
     with_view_model(
-        uart_text_input->view, 
-        UART_TextInputModel * model, 
-        { model->validator_text = furi_string_alloc(); }, 
+        uart_text_input->view,
+        UART_TextInputModel * model,
+        { model->validator_text = furi_string_alloc(); },
         false);
 
     uart_text_input_reset(uart_text_input);
@@ -875,9 +875,9 @@ void uart_text_input_free(UART_TextInput *uart_text_input)
 {
     furi_assert(uart_text_input);
     with_view_model(
-        uart_text_input->view, 
-        UART_TextInputModel * model, 
-        { furi_string_free(model->validator_text); }, 
+        uart_text_input->view,
+        UART_TextInputModel * model,
+        { furi_string_free(model->validator_text); },
         false);
 
     // Send stop command
@@ -921,11 +921,11 @@ View *uart_text_input_get_view(UART_TextInput *uart_text_input)
 }
 
 void uart_text_input_set_result_callback(
-    UART_TextInput *uart_text_input, 
-    UART_TextInputCallback callback, 
-    void *callback_context, 
-    char *text_buffer, 
-    size_t text_buffer_size, 
+    UART_TextInput *uart_text_input,
+    UART_TextInputCallback callback,
+    void *callback_context,
+    char *text_buffer,
+    size_t text_buffer_size,
     bool clear_default_text)
 {
     with_view_model(
@@ -948,8 +948,8 @@ void uart_text_input_set_result_callback(
 }
 
 void uart_text_input_set_validator(
-    UART_TextInput *uart_text_input, 
-    UART_TextInputValidatorCallback callback, 
+    UART_TextInput *uart_text_input,
+    UART_TextInputValidatorCallback callback,
     void *callback_context)
 {
     with_view_model(
@@ -962,14 +962,14 @@ void uart_text_input_set_validator(
         true);
 }
 
-UART_TextInputValidatorCallback 
+UART_TextInputValidatorCallback
 uart_text_input_get_validator_callback(UART_TextInput *uart_text_input)
 {
     UART_TextInputValidatorCallback validator_callback = NULL;
     with_view_model(
-        uart_text_input->view, 
-        UART_TextInputModel * model, 
-        { validator_callback = model->validator_callback; }, 
+        uart_text_input->view,
+        UART_TextInputModel * model,
+        { validator_callback = model->validator_callback; },
         false);
     return validator_callback;
 }
@@ -978,9 +978,9 @@ void *uart_text_input_get_validator_callback_context(UART_TextInput *uart_text_i
 {
     void *validator_callback_context = NULL;
     with_view_model(
-        uart_text_input->view, 
-        UART_TextInputModel * model, 
-        { validator_callback_context = model->validator_callback_context; }, 
+        uart_text_input->view,
+        UART_TextInputModel * model,
+        { validator_callback_context = model->validator_callback_context; },
         false);
     return validator_callback_context;
 }


### PR DESCRIPTION
If firmware implements RECORD_RPC_KEYBOARD v1.xx, we will accept keystrokes and text from the remote keyboard. This enables creating Pre-Save text using a mobile phone or a xbox 360 chatpad.

-

text_input's view_on_enter checks for furi_record_exists(RECORD_RPC_KEYBOARD). If it exists, then it wires up event notification, otherwise it does the default behavior.

in the draw routing, invoke_callback is always false so no change there either (unless an RPC_KEYBOARD sets it to true). Then we attempt to queue the validation and invoke the completion callback.

small bug fix to set focus on actual 'save' button.